### PR TITLE
Cz/histograms

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -89,13 +89,13 @@ def window_layout():
                                                               img_size[1]))
 
     def show_hist(r_dict):
-        o_hist = r_dict['Original histogram']
+        o_hist = r_dict['original_histograms']
         o_hist = o_hist[0] if type(o_hist) == list else o_hist
         o_hist = Image.open(decode_img(o_hist))
         o_hist = ImageTk.PhotoImage(o_hist.resize((250, 200)))
         o_hist_canv.create_image(125, 100, image=o_hist)
         o_hist_canv.create_text(70, 20, text='Original Histogram')
-        p_hist = r_dict['Processed histogram']
+        p_hist = r_dict['processed_histograms']
         p_hist = p_hist[0] if type(p_hist) == list else p_hist
         p_hist = Image.open(decode_img(p_hist))
         p_hist = ImageTk.PhotoImage(p_hist.resize((250, 200)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest-pep8
 requests
 flask
 pymodm
+skimage

--- a/testclient.py
+++ b/testclient.py
@@ -35,14 +35,17 @@ def hist_equal_filter(before_filtering):
 def local_load_filter_display(base64_string):
     img = decode_b64(base64_string, 'JPG')
     after_filtering = hist_equal_filter(img)
-    fig, ax = plt.subplots(1, 2)
-    ax[0].imshow(img)
-    ax[1].imshow(after_filtering)
+    fig, ax = plt.subplots(2, 2)
+    ax[0,0].imshow(img)
+    ax[0,1].imshow(after_filtering)
+    img_hist, img_bins = exposure.histogram(after_filtering)
+    ax[1,0].plot(img_bins, img_hist)
     plt.show()
+    print()
 
 
 def remote_filter_display(base64_string):
-    j = {'username': 'test001',
+    j = {'username': 'test003',
          'num_img': 1,
          'imgs': [base64_string],
          'procedure': 'reverse_vid',
@@ -50,13 +53,19 @@ def remote_filter_display(base64_string):
          'filename': 'airplane001.jpg'
          }
     r = requests.post(address + "/api/process_img", json=j)
-    print(r.text)
+    # print(r.text)
     r = r.json()
     imgs = r['processed_img']
-    for i in imgs:
-        decoded_img = decode_b64(i, 'JPG')
-        plt.imshow(decoded_img)
-        plt.show()
+    original_img = decode_b64(base64_string, 'JPG')
+    decoded_img = decode_b64(imgs[0], 'JPG')
+    figure, ax = plt.subplots(2,2)
+    original_histograms = r['original_histograms'][0]
+    processed_histograms = r['processed_histograms'][0]
+    ax[0,0].imshow(original_img)
+    ax[0,1].imshow(decoded_img)
+    ax[1,0].plot(original_histograms[0], original_histograms[1])
+    ax[1,1].plot(processed_histograms[0], processed_histograms[1])
+    plt.show()
 
 
 def encode_b64(image):
@@ -94,7 +103,7 @@ if __name__ == '__main__':
     # reencoded_b64 = encode_b64(img)
     # print(reencoded_b64)
     # local_load_filter_display(img_b64_string)
-    # remote_filter_display(img_b64_string)
+    remote_filter_display(img_b64_string)
     # hist_equal_filter(img_b64_string)
     # save_b64_image(b64_string)
 


### PR DESCRIPTION
@Yuhan-Liu-Heidi 

I added the histograms for process_img POST request and retrieve_request GET request.
The keys are 'original_histograms' and 'processed_histograms'. Each key references a list. Each element in the list is a tuple with two values (bins, hist). 
[(img1_bins, img1_hist), (img2_bins, img2_hist)]
When you plot, just plot(bins, hist) for each image. We talked about plotting only one image, so you would just call r['original_histograms'][0] to extract the first entry.

I included an example on histogram plotting below
https://github.com/NicolasHu11/BME547Final/blob/2f72a61fd323a4b28d34f44b1af3fddd5dda0b15/testclient.py#L62-L68
